### PR TITLE
Maritaca AI - Tests and Deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ project_assets/scripts/outputs/descriptions/?*.csv
 project_assets/scripts/outputs/faiss/?*.faiss
 project_assets/scripts/outputs/faiss/?*.pkl
 .gitignore
+
+**/.env

--- a/project_assets/tests/LLMs/requirements.txt
+++ b/project_assets/tests/LLMs/requirements.txt
@@ -2,3 +2,5 @@ transformers
 pandas
 torch
 accelerate
+openai
+python-dotenv

--- a/webapp/FastAPI/requirements.txt
+++ b/webapp/FastAPI/requirements.txt
@@ -92,3 +92,4 @@ deep-translator==1.11.4
 sentence-transformers==4.1.0
 pandas==2.2.3
 hf-xet==1.1.2
+openai==1.58.1


### PR DESCRIPTION
This pull request introduces support for using the Maritaca AI API (via the `openai` Python package) for story generation in both testing and production code, while also improving code formatting and configuration. The changes enable the use of Maritaca-hosted models (`sabia-3`, `sabiazinho-3`) alongside local Hugging Face models, and refactor the FastAPI route to use the API client instead of loading a local model.

**Integration of Maritaca AI API and OpenAI client:**

* Added `openai` and `python-dotenv` to `project_assets/tests/LLMs/requirements.txt` and `openai==1.58.1` to `webapp/FastAPI/requirements.txt` to support API-based model inference. [[1]](diffhunk://#diff-3a9a41c5eafd99d0083020c403fdd0bcd508324907d42d3fc2159c5d2f5dc787R5-R6) [[2]](diffhunk://#diff-ad39b57b757a1a097c9816ed091b7776ed48dedfc46f39416f455a7b7c05308cR95)
* In `project_assets/tests/LLMs/testLlm.py`, integrated the Maritaca AI API using the `openai` client for models `"sabia-3"` and `"sabiazinho-3"`, loading the API key from environment variables. Test logic now dynamically chooses between local and API models. [[1]](diffhunk://#diff-f02c2c364c6fff13c2f12a8c63615cecd8adf102b99763fa3ea64b2d9cedcfcbR5-R27) [[2]](diffhunk://#diff-f02c2c364c6fff13c2f12a8c63615cecd8adf102b99763fa3ea64b2d9cedcfcbR39-R87)
* In `webapp/FastAPI/routes/art_routes.py`, replaced the Hugging Face model loading and inference with a Maritaca AI API client using the `openai` package, and refactored the `generate_story` endpoint to generate stories via the API. [[1]](diffhunk://#diff-f64dfccd40817c3d71a763b7d7d11b1b4400b1ffce1f68176f43851a11511348L8-R9) [[2]](diffhunk://#diff-f64dfccd40817c3d71a763b7d7d11b1b4400b1ffce1f68176f43851a11511348L18-R22) [[3]](diffhunk://#diff-f64dfccd40817c3d71a763b7d7d11b1b4400b1ffce1f68176f43851a11511348L198-R206)

These changes make it easier to test and deploy story generation using both local and API-based models, and lay the groundwork for more flexible model selection in the future.